### PR TITLE
Recognise "eg" (exempli gratia) as an examples folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Hello World!
 
 ## Conventions
 
-The convention is simple, if there is an `examples` or `samples` folder 
+The convention is simple, if there is an `examples`, `samples` or `eg` folder
 in the directory the tool is executed in, it will fetch all csproj files 
 and find the best match to the query.
 

--- a/src/Example/ExampleFinder.cs
+++ b/src/Example/ExampleFinder.cs
@@ -49,8 +49,9 @@ namespace Example
         {
             var result = new List<ProjectInformation>();
 
-            var examples = FindProjects("examples").Concat(FindProjects("samples"));
-            foreach (var example in examples)
+            var examples = new[] { "examples", "samples", "eg" };
+            foreach (var example in examples.Select(FindProjects)
+                                            .Aggregate((a, x) => a.Concat(x)))
             {
                 result.Add(_parser.Parse(example));
             }


### PR DESCRIPTION
This PR allows `eg` to be recognised as an examples folder, in addition to `examples` and `samples`.

---
Eventually, I think a more flexible option might be needed where a project can declare its examples folder and/or where it can be found rather hardwiring a canned list. I was thinking looking for `.examples`, which could contain the path to the sub-folder where examples can be found.