### PR TITLE
Fix order parsing condition

### DIFF
--- a/src/Example/ProjectParser.cs
+++ b/src/Example/ProjectParser.cs
@@ -46,8 +46,7 @@ namespace Example
             // Got an order?
             var order = 1024;
             var orderString = Parse(xml, "//ExampleOrder");
-            if (string.IsNullOrWhiteSpace(orderString) &&
-                int.TryParse(orderString, out var orderInteger))
+            if (int.TryParse(orderString, out var orderInteger))
             {
                 order = orderInteger;
             }


### PR DESCRIPTION
This PR fixes a bug with the parsing of `ExampleOrder` parsing, which caused it to be completely ignored if specified. The check for a null or blank was inverted and actually redundant since `int.TryParse` can handle both.
