### PR TITLE
Update "Microsoft.CodeAnalysis.CSharp" to latest release

### DIFF
--- a/src/Example/Example.csproj
+++ b/src/Example/Example.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="MinVer" PrivateAssets="All" Version="2.3.1" />
     <PackageReference Include="Spectre.Cli" Version="0.46.0" />
     <PackageReference Include="Spectre.IO" Version="0.1.0" />


### PR DESCRIPTION
This PR updates [Microsoft.CodeAnalysis.CSharp](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp) to the latest release otherwise new keywords introduced with C# 9 like `record` don't appear highlighted/coloured.