### PR TITLE
Allow examples folders to be customised

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The convention is simple, if there is an `examples` or `samples` folder
 in the directory the tool is executed in, it will fetch all csproj files 
 and find the best match to the query.
 
+If examples are located in unconventional folders, add a `.examples` file
+with the (relative) paths of the examples folders, one per line. Blank lines
+or lines starting with `#` in the `.examples` file are ignored.
+
 ## Example settings
 
 To change the name, description, and the order of an example, edit it's `csproj` file, and add the following section:

--- a/src/Example/Extensions/FileExtensions.cs
+++ b/src/Example/Extensions/FileExtensions.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.IO;
+using Spectre.IO;
+
+namespace Example
+{
+    public static class FileExtensions
+    {
+        public static IEnumerable<string> ReadLines(this IFile file)
+        {
+            using var stream = file.OpenRead();
+            using var reader = new StreamReader(stream);
+            while (reader.ReadLine() is { } line)
+                yield return line;
+        }
+    }
+}


### PR DESCRIPTION
Follow-up from discussion in PR #2, this PR allows an (optional) `.examples` file to specify one or more folders containing the examples. It enables the tool to be used by projects using other conventions than the hardwired ones (`examples` and `samples`).

If the `.examples` file does not exist, then the behaviour is the same as now (assuming conventional folders).

If the `.examples` file exists then it is parsed according to the following format:

- each line of the file specifies a path relative to the file itself
- blank lines are ignored
- lines starting with `#` are ignored and therefore can be used for comments

Paths are trimmed before use.

This PR renders PR #2 obsolete.
