### PR TITLE
Set `RollForward` to `LatestMajor`.

### DIFF
--- a/src/Example/Example.csproj
+++ b/src/Example/Example.csproj
@@ -7,6 +7,7 @@
     <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <PackageId>dotnet-example</PackageId>
+    <RollForward>LatestMajor</RollForward>
     <ToolCommandName>dotnet-example</ToolCommandName>
   </PropertyGroup>
 


### PR DESCRIPTION
This enables running `dotnet-example` when (e.g.) only .NET 7 is installed. This is a good practice for .NET global tools so that they work on future runtimes without needing updates.