### PR TITLE
Set RollForward=Major instead of LatestMajor.

### DIFF
--- a/src/Example/Example.csproj
+++ b/src/Example/Example.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <PackageId>dotnet-example</PackageId>
-    <RollForward>LatestMajor</RollForward>
+    <RollForward>Major</RollForward>
     <ToolCommandName>dotnet-example</ToolCommandName>
   </PropertyGroup>
 


### PR DESCRIPTION
In #9, I proposed `LatestMajor`. That is *usually* fine, but `Major` is preferable to make things more predictable; `Major` will prefer the runtime that the app was built for before rolling forward, while `LatestMajor` will always roll forward.