### PR TITLE
Set RunWorkingDirectory to repo root

### DIFF
--- a/src/Example/Example.csproj
+++ b/src/Example/Example.csproj
@@ -9,6 +9,7 @@
     <PackageId>dotnet-example</PackageId>
     <RollForward>Major</RollForward>
     <ToolCommandName>dotnet-example</ToolCommandName>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)/../..</RunWorkingDirectory> 
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Just a minor suggestion to change `RunWorkingDirectory` MSBuild property to repo root path to simplify first time IDE debugging  after forking the repo by reusing the examples in repo root.